### PR TITLE
Upgrade dependency on defmt to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ cortex-m-rt = "0.6.15"
 embedded-hal = { version = "0.2.5", features=["unproven"] }
 embedded-time = "0.12.0"
 
-defmt = "0.1.3"
-defmt-rtt = "0.1.0"
+defmt = "0.2.0"
+defmt-rtt = "0.2.0"
 panic-probe = "0.1.0"
 
 rp2040-hal = { git = "https://github.com/rp-rs/rp-hal", branch="main", features=["rt"] }


### PR DESCRIPTION
When installing probe run using
`cargo install --git https://github.com/rp-rs/probe-run --branch main`
as suggested by README.md, one currently gets version 0.2.4, which uses
defmt 0.2.

So, when following the README.md, one gets the following error message:

```
Error: defmt version mismatch: firmware is using 0.1, `probe-run` supports 0.2
suggestion: `cargo install` a different non-git version of `probe-run` that supports defmt 0.1
```

This can be fixed by updating the template to defmt 0.2.