### PR TITLE
Upgrade panic-probe to 0.2.0, enable print-defmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ embedded-time = "0.12.0"
 
 defmt = "0.2.0"
 defmt-rtt = "0.2.0"
-panic-probe = "0.1.0"
+panic-probe = { version = "0.2.0", features = ["print-defmt"] }
 
 rp2040-hal = { git = "https://github.com/rp-rs/rp-hal", branch="main", features=["rt"] }
 rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }


### PR DESCRIPTION
We were using an older version of panic-probe, update to the latest.
Also enable print-defmt feature on panic-probe so that panics are printed over rtt as well.