### PR TITLE
Upgrade to defmt-0.3.0 & refer to upstream version of probe-run

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-run-rp --chip RP2040"
+runner = "probe-run --chip RP2040"
 
 rustflags = [
   "-C", "linker=flip-link",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,23 +12,12 @@ cortex-m-rt = "0.7.0"
 embedded-hal = { version = "0.2.5", features=["unproven"] }
 embedded-time = "0.12.0"
 
-defmt = "0.2.0"
-defmt-rtt = "0.2.0"
-panic-probe = { version = "0.2.0", features = ["print-defmt"] }
+defmt = "0.3.0"
+defmt-rtt = "0.3.0"
+panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 
 rp2040-hal = { git = "https://github.com/rp-rs/rp-hal", branch="main", features=["rt"] }
 rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
-
-[features]
-default = [
-    "defmt-default",
-]
-defmt-default = []
-defmt-trace = []
-defmt-debug = []
-defmt-info = []
-defmt-warn = []
-defmt-error = []
 
 # cargo build/run
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It includes all of the `knurling-rs` tooling as showcased in https://github.com/
 
 `probe-run-rp` is configured as the default runner, so you can start your program as easy as
 ```
-cargo run --release
+DEFMT_LOG=trace cargo run --release
 ```
 
 ## Requirements
@@ -40,11 +40,11 @@ cargo install flip-link
 
 For a debug build
 ```
-cargo run
+DEFMT_LOG=trace cargo run
 ```
 For a release build
 ```
-cargo run --release
+DEFMT_LOG=trace cargo run --release
 ```
   
 ## License

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This template is intended as a starting point for developing your own firmware b
 
 It includes all of the `knurling-rs` tooling as showcased in https://github.com/knurling-rs/app-template (`defmt`, `defmt-rtt`, `panic-probe`, `flip-link`) to make development as easy as possible.
 
-`probe-run-rp` is configured as the default runner, so you can start your program as easy as
+`probe-run` is configured as the default runner, so you can start your program as easy as
 ```
 DEFMT_LOG=trace cargo run --release
 ```
@@ -16,11 +16,7 @@ DEFMT_LOG=trace cargo run --release
 
 - flip-link - this allows you to detect stack-overflows on the first core, which is the only supported target for now.
 
-- probe-run. Upstream support for RP2040 is not finished yet, so this template uses `probe-run-rp` for now.
-  `probe-run-rp` is a version of `probe-run` using a `probe-rs` fork with support for the RP2040 chip.
-  Note that this installs the binary with name `probe-run-rp`, so you can still have the original `probe-run` installed in parallel.
-
-  This is important because `probe-run-rp` ONLY works with the RP2040 chip.
+- probe-run. Upstream support for RP2040 was added with version 0.3.1.
 
 - A CMSIS-DAP probe. (JLink probes sort of work but are very unstable. Other probes won't work at all)
 
@@ -32,7 +28,7 @@ DEFMT_LOG=trace cargo run --release
 ## Installation of development dependencies
 ```
 rustup target install thumbv6m-none-eabi
-cargo install --git https://github.com/rp-rs/probe-run --branch rp2040-support
+cargo install probe-run
 cargo install flip-link
 ```
 


### PR DESCRIPTION
With probe-run switching to defmt-0.3.0, the project template should be updated  accordingly, to avoid error messages:
```
Error: defmt wire format version mismatch: firmware is using 0.2, `probe-run` supports 3
suggestion: `cargo install` a different version of `probe-run` that supports defmt 3
```
~~For now, this is only a draft and should not yet be merged, as the template points to probe-run-rp, which has not yet been upgraded to defmt-0.3.0.~~
