### PR TITLE
Use pico bsp

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,9 @@
+# Choose a default "cargo run" tool.
+# probe-run is recommended if you have a debugger
+# elf2uf2-rs loads firmware over USB when the rp2040 is in boot mode
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 runner = "probe-run --chip RP2040"
+# runner = "elf2uf2-rs -d
 
 rustflags = [
   "-C", "linker=flip-link",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,17 @@ defmt = "0.3.0"
 defmt-rtt = "0.3.0"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 
-rp2040-hal = { git = "https://github.com/rp-rs/rp-hal", branch="main", features=["rt"] }
-rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
+# We're using a Pico by default on this template
+pico = { git = "https://github.com/rp-rs/rp-hal", branch="main"}
+
+# but you can use any BSP. Uncomment this to use the pro_micro_rp2040 BSP instead
+# pro_micro_rp2040 = { git = "https://github.com/rp-rs/rp-hal", branch="main"}
+
+# If you're not going to use a Board Support Package you'll need these:
+#rp2040-hal = { git = "https://github.com/rp-rs/rp-hal", branch="main", features=["rt"] }
+#rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
+
+
 
 # cargo build/run
 [profile.dev]

--- a/memory.x
+++ b/memory.x
@@ -4,6 +4,8 @@ MEMORY {
     RAM   : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
+EXTERN(BOOT2_FIRMWARE)
+
 SECTIONS {
     /* ### Boot loader */
     .boot2 ORIGIN(BOOT2) :

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,18 +10,18 @@ use defmt_rtt as _;
 use embedded_hal::digital::v2::OutputPin;
 use embedded_time::fixed_point::FixedPoint;
 use panic_probe as _;
-use rp2040_hal as hal;
 
-use hal::{
+// Provide an alias for our BSP so we can switch targets quickly.
+// Uncomment the BSP you included in Cargo.toml, the rest of the code does not need to change.
+use pico as bsp;
+// use pro_micro_rp2040 as bsp;
+
+use bsp::hal::{
     clocks::{init_clocks_and_plls, Clock},
     pac,
     sio::Sio,
     watchdog::Watchdog,
 };
-
-#[link_section = ".boot2"]
-#[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
 
 #[entry]
 fn main() -> ! {
@@ -47,14 +47,14 @@ fn main() -> ! {
 
     let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
 
-    let pins = hal::gpio::Pins::new(
+    let pins = bsp::Pins::new(
         pac.IO_BANK0,
         pac.PADS_BANK0,
         sio.gpio_bank0,
         &mut pac.RESETS,
     );
 
-    let mut led_pin = pins.gpio25.into_push_pull_output();
+    let mut led_pin = pins.led.into_push_pull_output();
 
     loop {
         info!("on!");


### PR DESCRIPTION
The template is currently based around the HAL directly.
BSP's help remove a bunch of boilerplate that never changes (configuring boot2, providing xtal freq, etc), and are generally more newbie-friendly - we should encourage ourselves and others to use them instead!
This PR sets the BSP to Pico, with a few commented lines on how to switch this to the pro_micro_rp2040.

Do not merge this until the boot2 changes are merged into the BSPs (https://github.com/rp-rs/rp-hal/pull/153)
Resolves #9.