### PR TITLE
typo: fix misspelled elf2uf2-rs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@
 # elf2uf2-rs loads firmware over USB when the rp2040 is in boot mode
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 runner = "probe-run --chip RP2040"
-# runner = "elf2uf2-rs -d
+# runner = "elf2uf2-rs -d"
 
 rustflags = [
   "-C", "linker=flip-link",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
+    "rust-analyzer.cargo.target": "thumbv6m-none-eabi",
+    "rust-analyzer.checkOnSave.allTargets": false,
     "editor.formatOnSave": true
 }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cargo install flip-link
 # This is our suggested default 'runner'
 cargo install probe-run
 # If you want to use elf2uf2-rs instead of probe-run, instead do...
-cargo install elf2usb2-rs 
+cargo install elf2uf2-rs
 ```
 
 ## Running
@@ -45,8 +45,17 @@ For a release build
 ```
 DEFMT_LOG=trace cargo run --release
 ```
-  
+
+To load firmware directly into RP2040, for example you don't have a probe, comment and uncomment following lines in `.cargo/config.toml`:
+
+```
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# runner = "probe-run --chip RP2040"
+runner = "elf2uf2-rs -d"
+```
+
 <!-- ROADMAP -->
+
 ## Roadmap
 
 NOTE These packages are under active development. As such, it is likely to


### PR DESCRIPTION
In `README.md`, elf2uf2-rs has been misspelled as elf2usb2-rs in installation commands. In `.cargo/config.toml`, a quotation mark need to be added.
For users who use VS Code with Rust Analyzer, setting target architecture could help them to avoid warning like no tests module.