### PR TITLE
Improve layout + formatting of readme + runner info

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ Some of the options for your `runner` are listed below:
   $ cargo install elf2uf2-rs --locked
   ```
 
-  *Step 2* - Make sure your .cargo/config contains the following (it should by
-  default if you are working in this repository):
+  *Step 2* - Make sure your .cargo/config contains the following
 
   ```toml
   [target.thumbv6m-none-eabi]

--- a/README.md
+++ b/README.md
@@ -5,11 +5,33 @@ This template is intended as a starting point for developing your own firmware b
 It includes all of the `knurling-rs` tooling as showcased in https://github.com/knurling-rs/app-template (`defmt`, `defmt-rtt`, `panic-probe`, `flip-link`) to make development as easy as possible.
 
 `probe-run` is configured as the default runner, so you can start your program as easy as
-```
+```sh
 DEFMT_LOG=trace cargo run --release
 ```
 
-## Requirements
+If you aren't using a debugger, check out [alternative runners](#alternative-runners) for other options
+
+<!-- TABLE OF CONTENTS -->
+<details open="open">
+  
+  <summary><h2 style="display: inline-block">Table of Contents</h2></summary>
+  <ol>
+    <li><a href="#markdown-header-requirements">Requirements</a></li>
+    <li><a href="#installation-of-development-dependencies">Installation of development dependencies</a></li>
+    <li><a href="#running">Running</a></li>
+    <li><a href="#alternative-runners">Alternative runners</a></li>
+    <li><a href="#roadmap">Roadmap</a></li>
+    <li><a href="#contributing">Contributing</a></li>
+    <li><a href="#code-of-conduct">Code of conduct</a></li>
+    <li><a href="#license">License</a></li>
+    <li><a href="#contact">Contact</a></li>
+  </ol>
+</details>
+
+<!-- Requirements -->
+<details open="open">
+  <summary><h2 style="display: inline-block" id="requirements">Requirements</h2></summary>
+  
 - The standard Rust tooling (cargo, rustup) which you can install from https://rustup.rs/
 
 - Toolchain support for the cortex-m0+ processors in the rp2040 (thumbv6m-none-eabi)
@@ -25,34 +47,134 @@ DEFMT_LOG=trace cargo run --release
 
   More details on supported debug probes can be found in [debug_probes.md](debug_probes.md)
 
-## Installation of development dependencies
-```
+</details>
+
+<!-- Installation of development dependencies -->
+<details open="open">
+  <summary><h2 style="display: inline-block" id="installation-of-development-dependencies">Installation of development dependencies</h2></summary>
+
+```sh
 rustup target install thumbv6m-none-eabi
 cargo install flip-link
 # This is our suggested default 'runner'
 cargo install probe-run
 # If you want to use elf2uf2-rs instead of probe-run, instead do...
-cargo install elf2uf2-rs
+cargo install elf2uf2-rs --locked
 ```
 
-## Running
+</details>
 
+
+<!-- Running -->
+<details open="open">
+  <summary><h2 style="display: inline-block" id="running">Running</h2></summary>
+  
 For a debug build
-```
+```sh
 DEFMT_LOG=trace cargo run
 ```
 For a release build
-```
+```sh
 DEFMT_LOG=trace cargo run --release
 ```
 
-To load firmware directly into RP2040, for example you don't have a probe, comment and uncomment following lines in `.cargo/config.toml`:
+If you do not specify a DEFMT_LOG level, only `println!("")` statements will be printed  
+You can either set this inline (on Linux/MacOS)  
+```sh
+DEFMT_LOG=trace cargo run
+```
 
+or set the `environment variable` so that it applies to every `cargo run` call that follows.
+#### Linux/MacOS/unix
+```sh
+export DEFMT_LOG=trace
 ```
-[target.'cfg(all(target_arch = "arm", target_os = "none"))']
-# runner = "probe-run --chip RP2040"
-runner = "elf2uf2-rs -d"
+
+#### Windows
+- cmd
+```cmd
+set DEFMT_LOG=trace
 ```
+- powershell
+```ps1
+$Env:DEFMT_LOG = trace
+```
+
+Setting the DEFMT_LOG level for the current session  
+for bash
+```sh
+export DEFMT_LOG=trace
+```
+
+Windows users must set DEFMT_LOG once as a separate step before calling `cargo run`
+for cmd
+```cmd
+set DEFMT_LOG=trace
+```
+for powershell
+```ps1
+$Env:DEFMT_LOG = trace
+```
+
+```cmd
+cargo run
+```
+
+</details>
+<!-- ALTERNATIVE RUNNERS -->
+<details open="open">
+  <summary><h2 style="display: inline-block" id="alternative-runners">Alternative runners</h2></summary>
+
+If you don't have a debug probe or if you want to do interactive debugging you can set up an alternative runner for cargo.  
+
+Some of the options for your `runner` are listed below:
+
+* **Loading a UF2 over USB**  
+  *Step 1* - Install [`elf2uf2-rs`](https://github.com/JoNil/elf2uf2-rs):
+
+  ```console
+  $ cargo install elf2uf2-rs --locked
+  ```
+
+  *Step 2* - Make sure your .cargo/config contains the following (it should by
+  default if you are working in this repository):
+
+  ```toml
+  [target.thumbv6m-none-eabi]
+  runner = "elf2uf2-rs -d"
+  ```
+
+  The `thumbv6m-none-eabi` target may be replaced by the all-Arm wildcard
+  `'cfg(all(target_arch = "arm", target_os = "none"))'`.
+
+  *Step 3* - Boot your RP2040 into "USB Bootloader mode", typically by rebooting
+  whilst holding some kind of "Boot Select" button. On Linux, you will also need
+  to 'mount' the device, like you would a USB Thumb Drive.
+
+  *Step 4* - Use `cargo run`, which will compile the code and started the
+  specified 'runner'. As the 'runner' is the elf2uf2-rs tool, it will build a UF2
+  file and copy it to your RP2040.
+
+  ```console
+  $ cargo run --release --example pico_pwm_blink
+  ```
+
+* **Loading with picotool**  
+  As ELF files produced by compiling Rust code are completely compatible with ELF
+  files produced by compiling C or C++ code, you can also use the Raspberry Pi
+  tool [picotool](https://github.com/raspberrypi/picotool). The only thing to be
+  aware of is that picotool expects your ELF files to have a `.elf` extension, and
+  by default Rust does not give the ELF files any extension. You can fix this by
+  simply renaming the file.
+
+  This means you can't easily use it as a cargo runner - yet.
+
+  Also of note is that the special
+  [pico-sdk](https://github.com/raspberrypi/pico-sdk) macros which hide
+  information in the ELF file in a way that `picotool info` can read it out, are
+  not supported in Rust. An alternative is TBC.
+
+</details>
 
 <!-- ROADMAP -->
 
@@ -61,7 +183,7 @@ runner = "elf2uf2-rs -d"
 NOTE These packages are under active development. As such, it is likely to
 remain volatile until a 1.0.0 release.
 
-See the [open issues](https://github.com/rp-rs/rp-hal/issues) for a list of
+See the [open issues](https://github.com/rp-rs/rp2040-project-template/issues) for a list of
 proposed features (and known issues).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cargo run --release
 ```
 
 If you do not specify a DEFMT_LOG level, it will be set to `debug`.
-That means `println!("")`, `info!("")` and `debug!("")`  statements will be printed.
+That means `println!("")`, `info!("")` and `debug!("")` statements will be printed.
 If you wish to override this, you can change it in `.cargo/config.toml` 
 ```toml
 [env]
@@ -103,8 +103,8 @@ export DEFMT_LOG=trace
 ```
 
 #### Windows
-Windows users can only override DEFMT_LOG through `config.toml` or by setting
-the environment variable as a separate step before calling `cargo run`
+Windows users can only override DEFMT_LOG through `config.toml`
+or by setting the environment variable as a separate step before calling `cargo run`
 - cmd
 ```cmd
 set DEFMT_LOG=trace

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can also set this inline (on Linux/MacOS)
 DEFMT_LOG=trace cargo run
 ```
 
-or set the `environment variable` so that it applies to every `cargo run` call that follows:
+or set the _environment variable_ so that it applies to every `cargo run` call that follows:
 #### Linux/MacOS/unix
 ```sh
 export DEFMT_LOG=trace

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It includes all of the `knurling-rs` tooling as showcased in https://github.com/
 
 `probe-run` is configured as the default runner, so you can start your program as easy as
 ```sh
-DEFMT_LOG=trace cargo run --release
+cargo run --release
 ```
 
 If you aren't using a debugger, check out [alternative runners](#alternative-runners) for other options
@@ -71,33 +71,29 @@ cargo install elf2uf2-rs --locked
   
 For a debug build
 ```sh
-DEFMT_LOG=trace cargo run
+cargo run
 ```
 For a release build
 ```sh
-DEFMT_LOG=trace cargo run --release
+cargo run --release
 ```
 
-If you do not specify a DEFMT_LOG level, only `println!("")` statements will be printed  
-You can either set this inline (on Linux/MacOS)  
+If you do not specify a DEFMT_LOG level, it will be set to `debug`.
+That means `println!("")`, `info!("")` and `debug!("")`  statements will be printed.
+If you wish to override this, you can change it in `.cargo/config.toml` 
+```toml
+[env]
+DEFMT_LOG = "off"
+```
+You can also set this inline (on Linux/MacOS)  
 ```sh
 DEFMT_LOG=trace cargo run
 ```
 
-or set the `environment variable` so that it applies to every `cargo run` call that follows.
+or set the `environment variable` so that it applies to every `cargo run` call that follows:
 #### Linux/MacOS/unix
 ```sh
 export DEFMT_LOG=trace
-```
-
-#### Windows
-- cmd
-```cmd
-set DEFMT_LOG=trace
-```
-- powershell
-```ps1
-$Env:DEFMT_LOG = trace
 ```
 
 Setting the DEFMT_LOG level for the current session  
@@ -106,12 +102,14 @@ for bash
 export DEFMT_LOG=trace
 ```
 
-Windows users must set DEFMT_LOG once as a separate step before calling `cargo run`
-for cmd
+#### Windows
+Windows users can only override DEFMT_LOG through `config.toml` or by setting
+the environment variable as a separate step before calling `cargo run`
+- cmd
 ```cmd
 set DEFMT_LOG=trace
 ```
-for powershell
+- powershell
 ```ps1
 $Env:DEFMT_LOG = trace
 ```


### PR DESCRIPTION
The README.md for rp2040-hal had significantly better quality and layout.
I've borrowed those plus added some details sections to allow the page to collapse.
Also borrowed info on using elf2uf2-rs from rp2040-hal README.md

This addresses some of #16