### PR TITLE
Fix BSP name: pico to rp-pico, rp_pico

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ defmt-rtt = "0.3.0"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 
 # We're using a Pico by default on this template
-pico = { git = "https://github.com/rp-rs/rp-hal", branch="main"}
+rp-pico = { git = "https://github.com/rp-rs/rp-hal", branch="main"}
 
 # but you can use any BSP. Uncomment this to use the pro_micro_rp2040 BSP instead
 # pro_micro_rp2040 = { git = "https://github.com/rp-rs/rp-hal", branch="main"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use panic_probe as _;
 
 // Provide an alias for our BSP so we can switch targets quickly.
 // Uncomment the BSP you included in Cargo.toml, the rest of the code does not need to change.
-use pico as bsp;
+use rp_pico as bsp;
 // use pro_micro_rp2040 as bsp;
 
 use bsp::hal::{


### PR DESCRIPTION
Since BSP rp-pico has been renamed from pico (https://github.com/rp-rs/rp-hal/pull/245/commits/8f0a2788eb05813f61c38eb502fc88b5bba749b7), we cannot build this template. This commit will fix it.