### PR TITLE
Set DEFMT_LOG to "debug" from .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -21,3 +21,6 @@ rustflags = [
 
 [build]
 target = "thumbv6m-none-eabi"
+
+[env]
+DEFMT_LOG = "debug"


### PR DESCRIPTION
This is for discussion: Since changing to defmt 0.3.0, most of the time I run a new firmware for the first time, I forget to set DEFMT_LOG. And during development, I usually want more logging than the default. So I wonder if it would be good to set this by default on rp2040-project-template.

Pro:
- it's usually a better choice when starting a new project
- easier for new users (avoids questions like "why doesn't `info!(...)` work?")

Con:
- quite invisible, so new users don't learn about DEFMT_LOG