### PR TITLE
Cargo toml updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
-authors = ["the rp-rs team"]
 edition = "2021"
-readme = "README.md"
 name = "rp2040-project-template"
 version = "0.1.0"
-resolver = "2"
 
 [dependencies]
 cortex-m = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["the rp-rs team"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 name = "rp2040-project-template"
 version = "0.1.0"


### PR DESCRIPTION
Update to latest Rust edition. This removes the requirement for resolver = "2" as this is the default.
Remove authors tag (not necessary + certain to be wrong after cloning the template).
Remove readme tag - cargo publish will automatically detect a README.md in the root of the package.