### PR TITLE
Add cargo embed config + docs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,11 @@
-# Choose a default "cargo run" tool.
-# probe-run is recommended if you have a debugger
-# elf2uf2-rs loads firmware over USB when the rp2040 is in boot mode
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# Choose a default "cargo run" tool:
+# - probe-run provides flashing and defmt via a hardware debugger
+# - cargo embed offers flashing, rtt, defmt and a gdb server via a hardware debugger
+#     it is configured via the Embed.toml in the root of this project
+# - elf2uf2-rs loads firmware over USB when the rp2040 is in boot mode
 runner = "probe-run --chip RP2040"
+# runner = "cargo embed"
 # runner = "elf2uf2-rs -d"
 
 rustflags = [

--- a/Embed.toml
+++ b/Embed.toml
@@ -1,0 +1,39 @@
+[default.probe]
+protocol = "Swd"
+speed = 20000
+# If you only have one probe cargo embed will pick automatically
+# Otherwise: add your probe's VID/PID/serial to filter
+
+## rust-dap
+# usb_vid = "6666"
+# usb_pid = "4444"
+# serial = "test"
+
+
+[default.flashing]
+enabled = true
+
+[default.reset]
+enabled = true
+halt_afterwards = false
+
+[default.general]
+chip = "RP2040"
+log_level = "WARN"
+# RP2040 does not support connect_under_reset
+connect_under_reset = false
+
+[default.rtt]
+enabled = true
+up_mode = "NoBlockSkip"
+channels = [
+    { up = 0, down = 0, name = "name", up_mode = "NoBlockSkip", format = "Defmt" },
+]
+timeout = 3000
+show_timestamps = true
+log_enabled = false
+log_path = "./logs"
+
+[default.gdb]
+enabled = false
+gdb_connection_string = "127.0.0.1:2345"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It includes all of the `knurling-rs` tooling as showcased in https://github.com/
 cargo run --release
 ```
 
-If you aren't using a debugger, check out [alternative runners](#alternative-runners) for other options
+If you aren't using a debugger (or want to use cargo-embed/probe-rs-debugger), check out [alternative runners](#alternative-runners) for other options
 
 <!-- TABLE OF CONTENTS -->
 <details open="open">
@@ -127,6 +127,32 @@ If you don't have a debug probe or if you want to do interactive debugging you c
 
 Some of the options for your `runner` are listed below:
 
+* **cargo embed**  
+  *Step 1* - Install [`cargo embed`](https://github.com/probe-rs/cargo-embed):
+
+  ```console
+  $ cargo install --force --git https://github.com/probe-rs/cargo-embed
+  ```
+
+  *Step 2* - Make sure your .cargo/config contains the following
+
+  ```toml
+  [target.thumbv6m-none-eabi]
+  runner = "cargo embed"
+  ```
+
+  *Step 3* - Update settings in [Embed.toml](./Embed.toml)  
+  - The defaults are to flash, reset, and start a defmt logging session
+  You can find all the settings and their meanings [in the cargo-embed repo](https://github.com/probe-rs/cargo-embed/blob/master/src/config/default.toml)
+
+  *Step 4* - Use `cargo run`, which will compile the code and start the
+  specified 'runner'. As the 'runner' is cargo embed, it will flash the device
+  and start running immediately
+
+  ```console
+  $ cargo run --release
+  ```
+
 * **Loading a UF2 over USB**  
   *Step 1* - Install [`elf2uf2-rs`](https://github.com/JoNil/elf2uf2-rs):
 
@@ -148,12 +174,12 @@ Some of the options for your `runner` are listed below:
   whilst holding some kind of "Boot Select" button. On Linux, you will also need
   to 'mount' the device, like you would a USB Thumb Drive.
 
-  *Step 4* - Use `cargo run`, which will compile the code and started the
+  *Step 4* - Use `cargo run`, which will compile the code and start the
   specified 'runner'. As the 'runner' is the elf2uf2-rs tool, it will build a UF2
   file and copy it to your RP2040.
 
   ```console
-  $ cargo run --release --example pico_pwm_blink
+  $ cargo run --release
   ```
 
 * **Loading with picotool**  

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 #![no_std]
 #![no_main]
 
-use cortex_m_rt::entry;
+use bsp::entry;
 use defmt::*;
 use defmt_rtt as _;
 use embedded_hal::digital::v2::OutputPin;


### PR DESCRIPTION
We previously only had probe-run as a debug configuration.
Now that cargo embed supports defmt, gdb and a bunch of other stuff we should document that as well.
Need to use a git version, since the latest release does not support rp2040 