### PR TITLE
config to allow nightly cross compile on aarch64 host

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,7 +10,8 @@ rustflags = [
   "-C", "link-arg=--nmagic",
   "-C", "link-arg=-Tlink.x",
   "-C", "link-arg=-Tdefmt.x",
-
+  "-C", "link-arg=--allow-multiple-definition",
+ 
   # Code-size optimizations.
   #   trap unreachable can save a lot of space, but requires nightly compiler.
   #   uncomment the next line if you wish to enable it

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,7 +10,9 @@ rustflags = [
   "-C", "link-arg=--nmagic",
   "-C", "link-arg=-Tlink.x",
   "-C", "link-arg=-Tdefmt.x",
-  "-C", "link-arg=--allow-multiple-definition",
+  # for nightly cross-compiles on non-Tier 1 Rust platform hosts
+  # uncomment the next line
+  # "-C", "link-arg=--allow-multiple-definition",
  
   # Code-size optimizations.
   #   trap unreachable can save a lot of space, but requires nightly compiler.
@@ -26,7 +28,8 @@ target = "thumbv6m-none-eabi"
 [env]
 DEFMT_LOG = "debug"
 
-# for cross-compiling using nightly
-[unstable]
-mtime-on-use = true
-build-std = ["core", "alloc"]
+# for cross-compiling using nightly on non-Tier 1 Rust platform hosts
+# uncoment the [unstable] section
+# [unstable]
+# mtime-on-use = true
+# build-std = ["core", "alloc"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -24,3 +24,8 @@ target = "thumbv6m-none-eabi"
 
 [env]
 DEFMT_LOG = "debug"
+
+# for cross-compiling using nightly
+[unstable]
+mtime-on-use = true
+build-std = ["core", "alloc"]

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           target: thumbv6m-none-eabi
+          components: rust-src
       - run: cargo install flip-link
       - run: cargo build --all
       - run: cargo build --all --release

--- a/README.md
+++ b/README.md
@@ -217,6 +217,18 @@ Some of the options for your `runner` are listed below:
 
 </details>
 
+#### using nightly compiler
+
+If you want to use the nightly compiler, especially on non-Tier 1 platforms (e.g.
+macOS with Apple Silicon), please see the `.cargo/config.toml` file for
+instructions in the rustflags list and the unstable section.
+
+Example invocation:
+
+```console
+cargo +nightly run --release
+```
+
 <!-- ROADMAP -->
 
 ## Roadmap


### PR DESCRIPTION
my host is macOS on apple silicon CPU. There Rust nightly does not bring pre-cross-compiled core and alloc for armv6.
Since that produces a weird error message, offering the necessary config in the template is advantageous I find.

practical application of this: working with RTIC v2 on the rp2040 requires use of nightly.