### PR TITLE
Update sparkfun-pro-micro-rp2040 bsp for rp2040-hal update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 rp-pico = "0.7"
 
 # but you can use any BSP. Uncomment this to use the pro_micro_rp2040 BSP instead
-# sparkfun-pro-micro-rp2040 = "0.3"
+# sparkfun-pro-micro-rp2040 = "0.6"
 
 # If you're not going to use a Board Support Package you'll need these:
 # rp2040-hal = { version="0.8", features=["rt", "critical-section-impl"] }


### PR DESCRIPTION
Version 0.3 of the sparkfun bsp relied on embedded-time for delay which in no longer present in repository after the rp2040-hal update.