### PR TITLE
Remove temporary workarounds for probe-run/defmt issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,7 @@ cortex-m = "0.7"
 cortex-m-rt = "0.7"
 embedded-hal = { version = "0.2.5", features = ["unproven"] }
 
-# Versions >0.3.4 contain a breaking change (wire format 4) and version 0.3.3 is yanked,
-# so we need to force version 0.3.2 for now to be compatible with the latest
-# working version of probe-run.
-defmt = "=0.3.2"
+defmt = "0.3"
 defmt-rtt = "0.4"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ If you aren't using a debugger (or want to use cargo-embed/probe-rs-debugger), c
 rustup target install thumbv6m-none-eabi
 cargo install flip-link
 # This is our suggested default 'runner'
-# (Because of https://github.com/knurling-rs/probe-run/issues/391, use an older version for now)
-cargo install probe-run --version=0.3.6 --locked
+cargo install probe-run --locked
 # If you want to use elf2uf2-rs instead of probe-run, instead do...
 cargo install elf2uf2-rs --locked
 ```


### PR DESCRIPTION
With probe-run 0.3.9, there's no longer a need to revert to older versions of probe-run and defmt to work around bugs.