### PR TITLE
Update probe-rs tools to 0.19

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,10 +2,10 @@
 # Choose a default "cargo run" tool:
 # - probe-run provides flashing and defmt via a hardware debugger, and stack unwind on panic
 # - elf2uf2-rs loads firmware over USB when the rp2040 is in boot mode
-# - "probe-rs-cli run" is similar to probe-run but it uses the latest probe-rs lib crate
+# - "probe-rs run" is similar to probe-run but it uses the latest probe-rs lib crate
 runner = "probe-run --chip RP2040"
 # runner = "elf2uf2-rs -d"
-# runner = "probe-rs-cli run --chip RP2040 --protocol swd"
+# runner = "probe-rs run --chip RP2040 --protocol swd"
 
 rustflags = [
   "-C", "linker=flip-link",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,9 +12,9 @@
             // RP2040 doesn't support connectUnderReset
             "connectUnderReset": false,
             "speed": 4000,
-            "runtimeExecutable": "probe-rs-debugger",
+            "runtimeExecutable": "probe-rs",
             "runtimeArgs": [
-                "debug"
+                "dap-server"
             ],
             "flashingConfig": {
                 "flashingEnabled": true,

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ cargo install elf2uf2-rs --locked
 # If you want to use any of the probe-rs tools (probe-rs run, cargo-embed, probe-rs-debugger)
 cargo install probe-rs --features=cli --locked
 ```
+In case you get an error ``binary `cargo-embed` already exists``, you might need to run `cargo uninstall cargo-embed` to uninstall an older version.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ If you aren't using a debugger (or want to use cargo-embed/probe-rs-debugger), c
     <li><a href="#installation-of-development-dependencies">Installation of development dependencies</a></li>
     <li><a href="#running">Running</a></li>
     <li><a href="#alternative-runners">Alternative runners</a></li>
-    <li><a href="#notes-on-using-rp2040_boot2">Notes on using rp2040_boot2</a></li>
     <li><a href="#roadmap">Roadmap</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#code-of-conduct">Code of conduct</a></li>
@@ -61,6 +60,8 @@ cargo install flip-link
 cargo install probe-run --locked
 # If you want to use elf2uf2-rs instead of probe-run, instead do...
 cargo install elf2uf2-rs --locked
+# If you want to use any of the probe-rs tools (probe-rs run, cargo-embed, probe-rs-debugger)
+cargo install probe-rs --features=cli --locked
 ```
 
 </details>
@@ -129,15 +130,15 @@ If you don't have a debug probe or if you want to do interactive debugging you c
 Some of the options for your `runner` are listed below:
 
 * **cargo embed**  
-  *Step 1* - Install [`cargo embed`](https://github.com/probe-rs/probe-rs/blob/master/cargo-embed):
+  *Step 1* - Install cargo-embed. This is part of the [`probe-rs`](https://crates.io/crates/probe-rs) crate:
 
   ```console
-  $ cargo install --locked cargo-embed
+  $ cargo install probe-rs --features=cli --locked
   ```
 
   *Step 2* - Update settings in [Embed.toml](./Embed.toml)  
   - The defaults are to flash, reset, and start a defmt logging session
-  You can find all the settings and their meanings [in the cargo-embed repo](https://github.com/probe-rs/probe-rs/blob/master/cargo-embed/src/config/default.toml)
+  You can find all the settings and their meanings [in the probe-rs repo](https://github.com/probe-rs/probe-rs/blob/c0610e98008cbb34d0dc056fcddff0f2d4f50ad5/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml)
 
   *Step 3* - Use the command `cargo embed`, which will compile the code, flash the device
   and start running the configuration specified in Embed.toml
@@ -147,35 +148,31 @@ Some of the options for your `runner` are listed below:
   ```
 
 * **probe-rs-debugger**
+  *Step 1* - Install Visual Studio Code from https://code.visualstudio.com/
 
-  *Step 1* - Download [`probe-rs-debugger VSCode plugin 0.4.0`](https://github.com/probe-rs/vscode/releases/download/v0.4.0/probe-rs-debugger-0.4.0.vsix)
-
-  *Step 2* - Install `probe-rs-debugger VSCode plugin`
+  *Step 2* - Install `probe-rs`
   ```console
-  $ code --install-extension probe-rs-debugger-0.4.0.vsix
+  $ cargo install probe-rs --features=cli --locked
   ```
 
-  *Step 3* - Install `probe-rs-debugger`
-  ```console
-  $ cargo install probe-rs-debugger
-  ```
+  *Step 3* - Open this project in VSCode
 
-  *Step 4* - Open this project in VSCode
+  *Step 4* - Install `debugger for probe-rs` via the VSCode extensions menu (View > Extensions)
 
   *Step 5* - Launch a debug session by choosing `Run`>`Start Debugging` (or press F5)
 
-* **probe-rs-cli**  
-  *Step 1* - Install [`probe-rs-cli`](https://crates.io/crates/probe-rs-cli):
+* **probe-rs run**
+  *Step 1* - Install [`probe-rs`](https://crates.io/crates/probe-rs-cli):
 
   ```console
-  $ cargo install probe-rs-cli
+  $ cargo install probe-rs --features=cli --locked
   ```
 
   *Step 2* - Make sure your .cargo/config contains the following
 
   ```toml
   [target.thumbv6m-none-eabi]
-  runner = "probe-rs-cli run --chip RP2040 --protocol swd"
+  runner = "probe-rs run --chip RP2040 --protocol swd"
   ```
 
   *Step 3* - Use `cargo run`, which will compile the code and start the
@@ -229,8 +226,6 @@ Some of the options for your `runner` are listed below:
   [pico-sdk](https://github.com/raspberrypi/pico-sdk) macros which hide
   information in the ELF file in a way that `picotool info` can read it out, are
   not supported in Rust. An alternative is TBC.
-
-</details>
 
 </details>
 <!-- Notes on using rp2040_hal and rp2040_boot2 -->

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ If you aren't using a debugger (or want to use cargo-embed/probe-rs-debugger), c
     <li><a href="#installation-of-development-dependencies">Installation of development dependencies</a></li>
     <li><a href="#running">Running</a></li>
     <li><a href="#alternative-runners">Alternative runners</a></li>
+    <li><a href="#notes-on-using-rp2040_boot2">Notes on using rp2040_boot2</a></li>
     <li><a href="#roadmap">Roadmap</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#code-of-conduct">Code of conduct</a></li>

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cargo install elf2uf2-rs --locked
 # If you want to use any of the probe-rs tools (probe-rs run, cargo-embed, probe-rs-debugger)
 cargo install probe-rs --features=cli --locked
 ```
-In case you get an error ``binary `cargo-embed` already exists``, you might need to run `cargo uninstall cargo-embed` to uninstall an older version.
+If you get the error ``binary `cargo-embed` already exists`` during installation of probe-rs, run `cargo uninstall cargo-embed` to uninstall your older version of cargo-embed before trying again.
 
 </details>
 


### PR DESCRIPTION
The latest version of probe-rs moved all of the tools behind a single crate - update instructions to use this.

Also updated probe-rs-debugger instructions, since you can now install the plugin through the regular extensions marketplace instead of having to manually install.

Lastly, removed a stray `</details>` tag - not sure when that got introduced