### PR TITLE
Fix project name in generated launch.json

### DIFF
--- a/cargo-generate/launch.json
+++ b/cargo-generate/launch.json
@@ -1,0 +1,45 @@
+// The format of this file is specified in https://probe.rs/docs/tools/vscode/#start-a-debug-session-with-minimum-configuration
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "preLaunchTask": "rust: cargo build",
+            "type": "probe-rs-debug",
+            "request": "launch",
+            "name": "rp2040-project",
+            "cwd": "${workspaceFolder}",
+            "chip": "rp2040",
+            // RP2040 doesn't support connectUnderReset
+            "connectUnderReset": false,
+            "speed": 4000,
+            "runtimeExecutable": "probe-rs",
+            "runtimeArgs": [
+                "dap-server"
+            ],
+            "flashingConfig": {
+                "flashingEnabled": true,
+                "resetAfterFlashing": true,
+                "haltAfterReset": true,
+            },
+            "coreConfigs": [
+                {
+                    "coreIndex": 0,
+                    "programBinary": "target/thumbv6m-none-eabi/debug/{{project-name}}",
+                    "chip": "RP2040",
+                    // Uncomment this if you've downloaded the SVD from
+                    // https://github.com/raspberrypi/pico-sdk/raw/1.3.1/src/rp2040/hardware_regs/rp2040.svd
+                    // and placed it in the .vscode directory
+                    // "svdFile": "./.vscode/rp2040.svd",
+                    "rttEnabled": true,
+                    "options": {
+                        "env": {
+                            "DEFMT_LOG": "debug"
+                        }
+                    },
+                }
+            ],
+            "consoleLogLevel": "Info", //Error, Warn, Info, Debug, Trace
+            "wireProtocol": "Swd"
+        }
+    ]
+}

--- a/cargo-generate/remove_rprs.rhai
+++ b/cargo-generate/remove_rprs.rhai
@@ -2,6 +2,8 @@ file::delete("README.md");
 file::delete("debug_probes.md");
 file::delete("CODE_OF_CONDUCT.md");
 file::delete("Cargo.toml");
+file::delete(".vscode/launch.json");
 file::rename("cargo-generate/Cargo.toml", "Cargo.toml");
 file::rename("cargo-generate/config.toml", ".cargo/config.toml");
+file::rename("cargo-generate/launch.json", ".vscode/launch.json");
 file::delete("cargo-generate")


### PR DESCRIPTION
The `.vscode/launch.json` file has a hard-coded path to the `programBinary`, which does not work if you create a project with a different name using `cargo generate rp-rs/rp2040-project-template`.

https://github.com/rp-rs/rp2040-project-template/blob/4cfa8a7d7b2991f77d85199b9d65296d54ced071/.vscode/launch.json#L27

This PR replaces that file with a generated `.vscode/launch.json` file, with the correct path to the `programBinary`. The rest of the file is unchanged.