### PR TITLE
Vscode improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,24 +18,17 @@
             ],
             "flashingConfig": {
                 "flashingEnabled": true,
-                "resetAfterFlashing": true,
-                "haltAfterReset": true,
+                "haltAfterReset": true
             },
             "coreConfigs": [
                 {
                     "coreIndex": 0,
                     "programBinary": "target/thumbv6m-none-eabi/debug/rp2040-project-template",
-                    "chip": "RP2040",
+                    "rttEnabled": true
                     // Uncomment this if you've downloaded the SVD from
                     // https://github.com/raspberrypi/pico-sdk/raw/1.3.1/src/rp2040/hardware_regs/rp2040.svd
                     // and placed it in the .vscode directory
                     // "svdFile": "./.vscode/rp2040.svd",
-                    "rttEnabled": true,
-                    "options": {
-                        "env": {
-                            "DEFMT_LOG": "debug"
-                        }
-                    },
                 }
             ],
             "consoleLogLevel": "Info", //Error, Warn, Info, Debug, Trace

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,4 +1,4 @@
-// The format of this file is specified in https://probe.rs/docs/tools/vscode/#start-a-debug-session-with-minimum-configuration
+// The format of this file is specified in https://probe.rs/docs/tools/debugger/#start-a-debug-session-with-minimum-configuration
 {
     "version": "0.2.0",
     "configurations": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
             ],
             "flashingConfig": {
                 "flashingEnabled": true,
-                "haltAfterReset": true
+                "haltAfterReset": false
             },
             "coreConfigs": [
                 {

--- a/cargo-generate/launch.json
+++ b/cargo-generate/launch.json
@@ -1,4 +1,4 @@
-// The format of this file is specified in https://probe.rs/docs/tools/vscode/#start-a-debug-session-with-minimum-configuration
+// The format of this file is specified in https://probe.rs/docs/tools/debugger/#start-a-debug-session-with-minimum-configuration
 {
     "version": "0.2.0",
     "configurations": [

--- a/cargo-generate/launch.json
+++ b/cargo-generate/launch.json
@@ -18,24 +18,17 @@
             ],
             "flashingConfig": {
                 "flashingEnabled": true,
-                "resetAfterFlashing": true,
-                "haltAfterReset": true,
+                "haltAfterReset": true
             },
             "coreConfigs": [
                 {
                     "coreIndex": 0,
                     "programBinary": "target/thumbv6m-none-eabi/debug/{{project-name}}",
-                    "chip": "RP2040",
+                    "rttEnabled": true
                     // Uncomment this if you've downloaded the SVD from
                     // https://github.com/raspberrypi/pico-sdk/raw/1.3.1/src/rp2040/hardware_regs/rp2040.svd
                     // and placed it in the .vscode directory
                     // "svdFile": "./.vscode/rp2040.svd",
-                    "rttEnabled": true,
-                    "options": {
-                        "env": {
-                            "DEFMT_LOG": "debug"
-                        }
-                    },
                 }
             ],
             "consoleLogLevel": "Info", //Error, Warn, Info, Debug, Trace

--- a/cargo-generate/launch.json
+++ b/cargo-generate/launch.json
@@ -18,7 +18,7 @@
             ],
             "flashingConfig": {
                 "flashingEnabled": true,
-                "haltAfterReset": true
+                "haltAfterReset": false
             },
             "coreConfigs": [
                 {


### PR DESCRIPTION
Updated the docs link for probe-rs debugger (the probe-rs folks move the page).
Cleared out a few settings that aren't used by newer versions of probe-rs debugger.

Also set haltAfterReset to false - it's confusing for new folks when you hit run but the board doesn't do anything. This would be okay if it ran to main and then halted (or opened main.rs), but as it's currently implemented it just looks like the debugger has hung.
I think it's a better default to have the setting disabled, but still present in the file in case they want to change it.