### PR TITLE
Fix incorrect options in comment

### DIFF
--- a/cargo-generate/launch.json
+++ b/cargo-generate/launch.json
@@ -31,7 +31,7 @@
                     // "svdFile": "./.vscode/rp2040.svd",
                 }
             ],
-            "consoleLogLevel": "Info", //Error, Warn, Info, Debug, Trace
+            "consoleLogLevel": "Info", //Error, Warn, Info, Debug
             "wireProtocol": "Swd"
         }
     ]


### PR DESCRIPTION
The comment after `consoleLogLevel` in `launch.json` implies you could set this value to `Trace`, which is incorrect.
See
https://github.com/probe-rs/vscode/blob/efeb1c5a737bc93ecd3a3503e905548b73e74b3c/package.json#L135-L149