### PR TITLE
Fix for cargo-generate@0.23.0 failing to create project from template

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,6 +1,6 @@
 [template]
 cargo_generate_version = ">=0.9.0"
-
+exclude = [".github/workflows/ci_checks.yml"]
 [hooks]
 pre = ["cargo-generate/remove_rprs.rhai"]
 


### PR DESCRIPTION
Creating a project using this template and  `cargo-generate@0.23.0` causes the following error which prevents the project from being created:

```
🤷   Project Name: test-rs
🔧   Destination: /tmp/test-rs ...
🔧   project-name: test-rs ...
🔧   Generating template ...
✔ 🤷   Which flashing method do you intend to use? · probe-rs
[ 1/17]   Done: .cargo/config.toml
[ 2/17]   Done: .cargo
[ 4/17]   Done: .github/workflows
[ 5/17]   Done: .github
[ 6/17]   Done: .gitignore
[ 7/17]   Done: .vscode/launch.json
[ 8/17]   Done: .vscode/settings.json
[ 9/17]   Done: .vscode
[10/17]   Done: APACHE2.0
[11/17]   Done: Cargo.toml
[12/17]   Done: Embed.toml
[13/17]   Done: MIT
[14/17]   Done: build.rs
[15/17]   Done: memory.x
[16/17]   Done: src/main.rs
[17/17]   Done: src

Error: Substitution skipped, found invalid syntax in
    .github/workflows/ci_checks.yml

Consider adding these files to a `cargo-generate.toml` in the template repo to skip substitution on these files.

Learn more: https://github.com/cargo-generate/cargo-generate#include--exclude.
```

This change adds `.github/workflows/ci_checks.yml` to the exclude block in `cargo-generate.yaml` which fixes the issue.

Note: I'm not sure which version of `cargo-generate` broke this, but I can confirm it previously worked fine with `cargo-generate@0.21.3`


Thanks for this template! It's been super helpful and saved me a bunch of time.