### PR TITLE
fix: remove inline-threshold from the config's template too

### DIFF
--- a/cargo-generate/config.toml
+++ b/cargo-generate/config.toml
@@ -25,7 +25,6 @@ rustflags = [
   #   trap unreachable can save a lot of space, but requires nightly compiler.
   #   uncomment the next line if you wish to enable it
   # "-Z", "trap-unreachable=no",
-  "-C", "inline-threshold=5",
   "-C", "no-vectorize-loops",
 ]
 


### PR DESCRIPTION
This change mirros 8f7b4b67.

When fetching through cargo-generate, a different file is used to build the config file.

Fixes #97