### PR TITLE
fix: Update cargo's config to use the new linker parameter

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,8 +5,8 @@
 runner = "probe-rs run --chip RP2040 --protocol swd"
 # runner = "elf2uf2-rs -d"
 
+linker = "flip-link"
 rustflags = [
-  "-C", "linker=flip-link",
   "-C", "link-arg=--nmagic",
   "-C", "link-arg=-Tlink.x",
   "-C", "link-arg=-Tdefmt.x",

--- a/cargo-generate/config.toml
+++ b/cargo-generate/config.toml
@@ -15,8 +15,8 @@
       runner = "{{ flash_method_custom }}"
     {%- endif -%}
 {%- endcase %}
+linker = "flip-link"
 rustflags = [
-  "-C", "linker=flip-link",
   "-C", "link-arg=--nmagic",
   "-C", "link-arg=-Tlink.x",
   "-C", "link-arg=-Tdefmt.x",


### PR DESCRIPTION
Since rust v1.74, the linker can be selected without using rustflags. This plays nicer with `RUSTFLAGS`.

Fixes #82 