### PR TITLE
Use edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "rp2040-project-template"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use rp_pico as bsp;
 // use sparkfun_pro_micro_rp2040 as bsp;
 
 use bsp::hal::{
-    clocks::{init_clocks_and_plls, Clock},
+    clocks::{Clock, init_clocks_and_plls},
     pac,
     sio::Sio,
     watchdog::Watchdog,


### PR DESCRIPTION
See https://github.com/rp-rs/rp235x-project-template/pull/5 for more context.

Currently, this repository specifies edition 2021 in `Cargo.toml`, but it seems `cargo generate` generates a crate with the default edition of the toolchain. This means an ordinary user would use edition 2024 for a fresh project. So, I think it's a good idea to test edition 2024 instead of 2021 for testing on GitHub Actions CI.